### PR TITLE
Conky fails to build with curl useflag if this patch is not applied. Patc

### DIFF
--- a/app-admin/conky/conky-1.8.1-r2.ebuild
+++ b/app-admin/conky/conky-1.8.1-r2.ebuild
@@ -57,6 +57,7 @@ src_prepare() {
 	epatch "${FILESDIR}/${P}-xmms2.patch"
 	epatch "${FILESDIR}/${P}-secunia-SA43225.patch"
 	epatch "${FILESDIR}/${P}-acpitemp.patch"
+	epatch "${FILESDIR}/${P}-curl-headers.patch"
 	epatch "${FILESDIR}/${PN}-fix_top.patch"
 }
 


### PR DESCRIPTION
Conky fails to build with curl useflag if this patch is not applied. Patch already in portage.
