### PR TITLE
The USE flag "ass" in mplayer & mplayer2 has been changed to "libass"

### DIFF
--- a/media-video/gnome-mplayer/gnome-mplayer-1.0.6.ebuild
+++ b/media-video/gnome-mplayer/gnome-mplayer-1.0.6.ebuild
@@ -30,7 +30,7 @@ COMMON_DEPEND=">=dev-libs/glib-2.26
 		)
 	pulseaudio? ( >=media-sound/pulseaudio-0.9.14 )"
 RDEPEND="${COMMON_DEPEND}
-	|| ( >=media-video/mplayer-1.0_rc4_p20100101[ass] media-video/mplayer2[ass] )"
+	|| ( >=media-video/mplayer-1.0_rc4_p20100101[libass] media-video/mplayer2[libass] )"
 DEPEND="${COMMON_DEPEND}
 	dev-util/pkgconfig
 	sys-devel/gettext"


### PR DESCRIPTION
The USE flag "ass" in mplayer & mplayer2 has been changed to "libass". So the changes.
