### PR TITLE
net-dns/avahi fails to build without patch from portage

### DIFF
--- a/net-dns/avahi/avahi-0.6.30-r4.ebuild
+++ b/net-dns/avahi/avahi-0.6.30-r4.ebuild
@@ -109,6 +109,7 @@ src_prepare() {
 	>py-compile
 
 	epatch "${FILESDIR}"/${P}-automake-1.11.2.patch #397477
+	epatch "${FILESDIR}"/${P}-parallel.patch #411351
 
 	eautoreconf
 }


### PR DESCRIPTION
Include the patch from portage
