### PR TITLE
media-libs/mediastreamer build fails without patch

### DIFF
--- a/media-libs/mediastreamer/mediastreamer-2.8.2.ebuild
+++ b/media-libs/mediastreamer/mediastreamer-2.8.2.ebuild
@@ -57,6 +57,8 @@ src_prepare() {
 	sed -i -e "s:\(doc_htmldir=\).*:\1\$(htmldir):" help/Makefile.am \
 		|| die "patching help/Makefile.am failed"
 
+	epatch ${FILESDIR}/${P}-autopoint.patch
+
 #	# linux/videodev.h dropped in 2.6.38
 #	sed -i -e 's:msv4l.c::' src/Makefile.am || die
 #	sed -i -e 's:linux/videodev.h ::' configure.ac || die


### PR DESCRIPTION
http://git.overlays.gentoo.org/gitweb/?p=user/bircoph.git;a=blob_plain;f=media-libs/mediastreamer/files/mediastreamer-2.8.2-autopoint.patch;hb=HEAD
This is a patch for configure.ac from bircoph overlay. Build fails without it.
