### PR TITLE
dev-libs/libstrophe

### DIFF
--- a/dev-libs/libstrophe/files/libstrophe-libxml2-build-fix.patch
+++ b/dev-libs/libstrophe/files/libstrophe-libxml2-build-fix.patch
@@ -1,0 +1,18 @@
+diff --git a/configure.ac b/configure.ac
+index 97444e5..e170fc3 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -9,11 +9,9 @@ AC_CHECK_HEADER(openssl/ssl.h, [], [AC_MSG_ERROR([couldn't find openssl headers,
+ PKG_CHECK_MODULES([check], [check >= 0.9.4], [], [AC_MSG_WARN([libcheck not found; unit tests will not be compilable])])
+ 
+ AC_ARG_WITH([libxml2],
+-            [AS_HELP_STRING([--with-libxml2], [use libxml2 for XML parsing])],
+-            [with_libxml2=check],
+-            [with_libxml2=no])
++            [AS_HELP_STRING([--with-libxml2], [use libxml2 for XML parsing])])
+ 
+-if test "x$with_libxml2" != xno; then
++if test "x$with_libxml2" = xyes; then
+   PKG_CHECK_MODULES([libxml2], [libxml-2.0 >= 2.7],
+                     [with_libxml2=yes],
+                     [AC_MSG_ERROR([couldn't find libxml2])])

--- a/dev-libs/libstrophe/libstrophe-9999.ebuild
+++ b/dev-libs/libstrophe/libstrophe-9999.ebuild
@@ -6,7 +6,7 @@ EAPI=4
 
 EGIT_REPO_URI="git://github.com/metajack/libstrophe.git"
 
-inherit autotools git-2
+inherit autotools eutils git-2
 
 DESCRIPTION="A simple, lightweight C library for writing XMPP clients"
 HOMEPAGE="http://strophe.im/libstrophe"
@@ -14,19 +14,34 @@ HOMEPAGE="http://strophe.im/libstrophe"
 LICENSE="MIT GPL-3"
 SLOT="0"
 KEYWORDS=""
-IUSE="xml"
+IUSE="doc xml"
 
-DEPEND="xml? ( dev-libs/libxml2 )
-			!xml? ( dev-libs/expat )
-			dev-libs/openssl"
-RDEPEND="${DEPEND}"
+RDEPEND="xml? ( dev-libs/libxml2 )
+		!xml? ( dev-libs/expat )
+		dev-libs/openssl"
+DEPEND="${RDEPEND}
+		doc? ( app-doc/doxygen )"
 
 S="${WORKDIR}/${P/-/_}"
 
 src_prepare() {
-			eautoreconf
+		epatch "${FILESDIR}"/${PN}-libxml2-build-fix.patch
+		eautoreconf
 }
 
 src_configure() {
-			econf $(use_with xml libxml2)
+		econf $(use_with xml libxml2)
+}
+
+src_compile() {
+		emake
+		if use doc; then
+			doxygen || die
+		fi
+}
+
+src_install() {
+		einstall
+		dodoc LICENSE.txt README.markdown
+		use doc && dohtml -r docs/html/*
 }


### PR DESCRIPTION
- Добавлен патч, без которого библиотека всегда собирается с поддержкой libxml2, независимо от флага xml
- Добавлен флаг doc
