### PR TITLE
rename libstrophe to libcouplet

### DIFF
--- a/dev-libs/libcouplet/libcouplet-9999.ebuild
+++ b/dev-libs/libcouplet/libcouplet-9999.ebuild
@@ -4,12 +4,12 @@
 
 EAPI=4
 
-EGIT_REPO_URI="git://github.com/pasis/libstrophe.git"
+EGIT_REPO_URI="git://github.com/pasis/libcouplet.git"
 
 inherit libtool autotools eutils git-2
 
-DESCRIPTION="A simple, lightweight C library for writing XMPP clients"
-HOMEPAGE="http://strophe.im/libstrophe"
+DESCRIPTION="Fork of libstrophe - a simple, lightweight C library for writing XMPP clients"
+HOMEPAGE=""
 
 LICENSE="MIT GPL-3"
 SLOT="0"

--- a/dev-libs/libcouplet/metadata.xml
+++ b/dev-libs/libcouplet/metadata.xml
@@ -3,6 +3,7 @@
 <pkgmetadata>
 	<maintainer>
 		<email>pasis.ua@gmail.com</email>
+		<name>Dmitry Podgorny</name>
 	</maintainer>
 	<use>
 		<flag name='xml'>Use dev-libs/libxml2 to parse XML</flag>

--- a/net-misc/pppoat/metadata.xml
+++ b/net-misc/pppoat/metadata.xml
@@ -3,6 +3,7 @@
 <pkgmetadata>
     <maintainer>
         <email>pasis.ua@gmail.com</email>
+        <name>Dmitry Podgorny</name>
     </maintainer>
     <use>
         <flag name='xmpp'>Enable xmpp module (PPP over Jabber)</flag>

--- a/net-misc/pppoat/pppoat-9999.ebuild
+++ b/net-misc/pppoat/pppoat-9999.ebuild
@@ -16,7 +16,7 @@ SLOT="0"
 KEYWORDS=""
 IUSE="-extra +xmpp"
 
-RDEPEND="xmpp? ( dev-libs/libstrophe )"
+RDEPEND="xmpp? ( dev-libs/libcouplet )"
 DEPEND="${RDEPEND}"
 
 S="${WORKDIR}/${P/-/_}"


### PR DESCRIPTION
- форк libstrophe переименован в libcouplet, следовательно, переимнованы и ебилды
- pppoat теперь зависит от libcouplet
