### PR TITLE
Fix a bug that shows up in appmenu-firefox

### DIFF
--- a/dev-libs/libdbusmenu-qt/files/use-qx11info-apptime.patch
+++ b/dev-libs/libdbusmenu-qt/files/use-qx11info-apptime.patch
@@ -1,0 +1,40 @@
+Description: Use the X appTime from QX11Info instead of system time.
+ Use the X appTime from QX11Info instead of system time.
+ .
+ libdbusmenu-qt (0.9.2-0yasi3) quantal; urgency=low
+ .
+   * Fix X current timestamp
+Author: Joe Yasi <joe.yasi@gmail.com>
+
+---
+The information above should follow the Patch Tagging Guidelines, please
+checkout http://dep.debian.net/deps/dep3/ to learn about the format. Here
+are templates for supplementary fields that you might want to add:
+
+Origin: <vendor|upstream|other>, <url of original patch>
+Bug: <url in upstream bugtracker>
+Bug-Debian: http://bugs.debian.org/<bugnumber>
+Bug-Ubuntu: https://launchpad.net/bugs/<bugnumber>
+Forwarded: <no|not-needed|url proving that it has been forwarded>
+Reviewed-By: <name and email of someone who approved the patch>
+Last-Update: <YYYY-MM-DD>
+
+--- libdbusmenu-qt-0.9.2.orig/src/dbusmenuimporter.cpp
++++ libdbusmenu-qt-0.9.2/src/dbusmenuimporter.cpp
+@@ -34,6 +34,7 @@
+ #include <QTimer>
+ #include <QToolButton>
+ #include <QWidgetAction>
++#include <QX11Info>
+ 
+ // Local
+ #include "dbusmenutypes_p.h"
+@@ -276,7 +277,7 @@ public:
+     void sendEvent(int id, const QString &eventId)
+     {
+         QVariant empty = QVariant::fromValue(QDBusVariant(QString()));
+-        uint timestamp = QDateTime::currentDateTime().toTime_t();
++        uint timestamp = QX11Info::appTime();
+         m_interface->asyncCall("Event", id, eventId, empty, timestamp);
+     }
+ };

--- a/dev-libs/libdbusmenu-qt/libdbusmenu-qt-0.9.2-r1.ebuild
+++ b/dev-libs/libdbusmenu-qt/libdbusmenu-qt-0.9.2-r1.ebuild
@@ -1,0 +1,66 @@
+# Copyright 1999-2012 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Header: /var/cvsroot/gentoo-x86/dev-libs/libdbusmenu-qt/libdbusmenu-qt-0.8.2.ebuild,v 1.5 2011/06/26 01:56:02 ranger Exp $
+
+EAPI=4
+
+QT_DEPEND="4.6.3"
+EGIT_REPO_URI="git://gitorious.org/dbusmenu/dbusmenu-qt.git"
+
+[[ ${PV} == 9999* ]] && GIT_ECLASS="git-2"
+inherit cmake-utils virtualx ${GIT_ECLASS}
+
+DESCRIPTION="A library providing Qt implementation of DBusMenu specification"
+HOMEPAGE="https://launchpad.net/libdbusmenu-qt/"
+if [[ ${PV} == 9999* ]] ; then
+	KEYWORDS=""
+else
+	#SRC_URI="http://launchpad.net/${PN}/trunk/${PV}/+download/${P}.tar.bz2"
+	# upstream has no permissions to use some kde written code so repack git
+	# repo every time
+	SRC_URI="http://launchpad.net/${PN}/trunk/${PV}/+download/${PN}-${PV}.tar.bz2"
+	KEYWORDS="amd64 ~arm ppc ~ppc64 x86 ~amd64-linux ~x86-linux"
+fi
+
+LICENSE="LGPL-2"
+SLOT="0"
+IUSE="debug doc"
+
+RDEPEND="
+	>=dev-qt/qtcore-${QT_DEPEND}:4
+	>=dev-qt/qtgui-${QT_DEPEND}:4[dbus]
+	>=dev-qt/qttest-${QT_DEPEND}:4
+"
+DEPEND="${RDEPEND}
+	doc? ( app-doc/doxygen )
+	test? (
+		dev-libs/qjson
+		>=dev-qt/qttest-${QT_DEPEND}:4
+	)
+"
+
+DOCS=(NEWS README)
+
+# Fix a bug that shows up in appmenu-firefox, see:
+# https://bugs.launchpad.net/libdbusmenu-qt/+bug/1035755
+PATCHES=( "${FILESDIR}/use-qx11info-apptime.patch" )
+
+# tests fail due to missing conection to dbus
+RESTRICT="test"
+
+src_configure() {
+	local mycmakeargs=(
+		$(cmake-utils_use_build test TESTS)
+		$(cmake-utils_use_with doc)
+	)
+	cmake-utils_src_configure
+}
+
+src_test() {
+	local builddir=${CMAKE_BUILD_DIR}
+
+	CMAKE_BUILD_DIR=${CMAKE_BUILD_DIR}/tests \
+		VIRTUALX_COMMAND=cmake-utils_src_test virtualmake
+
+	CMAKE_BUILD_DIR=${builddir}
+}


### PR DESCRIPTION
When using appmenu-firefox, the menus (right-click menus, Window menubar's menus, etc.) flicker and sometimes disappear until firefox is restarted.

Here:
https://bugs.launchpad.net/libdbusmenu-qt/+bug/1035755

A patch is proposed, I just applied it to the ebuild and checked that it works now.
It's not upstream yet, however.

I haven't filed a bug in Gentoo, even though their libdbusmenu-qt has the same bug, because you need appmenu-firefox to reproduce it, and it's only in your overlay ATM.
I'm not sure if we should do that, and how. Should I file a Gentoo bug?
