### PR TITLE
media-gfx/inkscape-9999: fixed grabbing of changelog

### DIFF
--- a/media-gfx/inkscape/inkscape-9999.ebuild
+++ b/media-gfx/inkscape/inkscape-9999.ebuild
@@ -76,7 +76,7 @@ src_configure(){
 	$(use_enable lcms)\
 	$(use_enable nls)\
 
-	DOCS="AUTHORS ChangeLog NEWS README*"
+	DOCS="AUTHORS ChangeLog* NEWS README*"
 
 	#./configure
 	# aliasing unsafe wrt #310393


### PR DESCRIPTION
changlog file has been renamed to ChangeLog-0.91 ... this fix also grabs future changes of the changelog file name
