### PR TITLE
Update thrift-0.9.1.ebuild

### DIFF
--- a/dev-libs/thrift/thrift-0.9.1.ebuild
+++ b/dev-libs/thrift/thrift-0.9.1.ebuild
@@ -78,5 +78,5 @@ src_compile() {
 }
 
 src_install() {
-	emake DESTDIR="${D}" install || die "emake install failed"
+	emake DESTDIR="${EPREFIX}/${D}" install || die "emake install failed"
 }


### PR DESCRIPTION
to build thrift on gentoo_prefix
