### PR TITLE
sonata: Install icon

### DIFF
--- a/media-sound/sonata/sonata-9999.ebuild
+++ b/media-sound/sonata/sonata-9999.ebuild
@@ -43,6 +43,8 @@ src_prepare() {
 src_install() {
 	distutils-r1_src_install
 	rm -rf "${D}"/usr/share/sonata
+	insinto /usr/share/pixmaps
+	newins sonata/pixmaps/sonata-large.png sonata.png
 }
 
 pkg_postinst() {


### PR DESCRIPTION
Not tested for self, as i installed it from this ebuild much earlier. When found, simply created symlink into one of python dir.
Or may be, you should remove data dir more selectively.